### PR TITLE
Feature/support added for multiple encodings

### DIFF
--- a/crates/llm-ls/src/document.rs
+++ b/crates/llm-ls/src/document.rs
@@ -1,8 +1,8 @@
-use ropey::{Rope, RopeSlice, Error as RopeyError};
-use tower_lsp::lsp_types::{ TextDocumentContentChangeEvent, Position};
+use ropey::{Error as RopeyError, Rope, RopeSlice};
+use tower_lsp::lsp_types::{Position, TextDocumentContentChangeEvent};
 use tree_sitter::{InputEdit, Parser, Point, Tree};
 
-use crate::error::{Result, Error as LspError};
+use crate::error::{Error as LspError, Result};
 use crate::language_id::LanguageId;
 
 fn get_parser(language_id: LanguageId) -> Result<Parser> {
@@ -182,7 +182,10 @@ impl Document {
                 let change_start_line = match self.text.get_line(change_start_line_idx) {
                     Some(line) => line,
                     None => {
-                        return Err(LspError::Rope(RopeyError::LineIndexOutOfBounds(change_start_line_idx, self.text.len_lines())));
+                        return Err(LspError::Rope(RopeyError::LineIndexOutOfBounds(
+                            change_start_line_idx,
+                            self.text.len_lines(),
+                        )));
                     }
                 };
 
@@ -196,7 +199,10 @@ impl Document {
                     false => match self.text.get_line(change_end_line_idx) {
                         Some(line) => line,
                         None => {
-                            return Err(LspError::Rope(RopeyError::LineIndexOutOfBounds(change_end_line_idx, self.text.len_lines())));
+                            return Err(LspError::Rope(RopeyError::LineIndexOutOfBounds(
+                                change_end_line_idx,
+                                self.text.len_lines(),
+                            )));
                         }
                     },
                 };

--- a/crates/llm-ls/src/document.rs
+++ b/crates/llm-ls/src/document.rs
@@ -222,7 +222,7 @@ impl Document {
                         PositionEncodingKind::UTF32 => Ok(position.character as usize),
                     }
                     .map_err(|err| {
-                        return LspError::Rope(err);
+                        LspError::Rope(err)
                     })
                 }
 
@@ -310,13 +310,13 @@ impl Document {
                                 .expect("parse should always return a tree when the language was set and no timeout was specified"));
                 }
 
-                return Ok(());
+                Ok(())
             }
             None => {
                 self.text = Rope::from_str(&change.text);
                 self.tree = self.parser.parse(&change.text, None);
 
-                return Ok(());
+                Ok(())
             }
         }
     }

--- a/crates/llm-ls/src/main.rs
+++ b/crates/llm-ls/src/main.rs
@@ -539,18 +539,18 @@ impl LanguageServer for LlmService {
             .and_then(|general_capabilities| {
                 general_capabilities
                     .position_encodings
-                    .and_then(|encodings| {
+                    .map(|encodings| {
                         if encodings.contains(&PositionEncodingKind::UTF8) {
-                            Some(PositionEncodingKind::UTF8)
+                            PositionEncodingKind::UTF8
                         } else if encodings.contains(&PositionEncodingKind::UTF16) {
-                            Some(PositionEncodingKind::UTF16)
+                            PositionEncodingKind::UTF16
                         } else if encodings.contains(&PositionEncodingKind::UTF32) {
-                            Some(PositionEncodingKind::UTF32)
+                            PositionEncodingKind::UTF32
                         } else {
                             // Because UTF-16 is the only mandatory encoding that the client must support,
                             // we will use it as the default encoding.
                             // See: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocuments
-                            Some(PositionEncodingKind::UTF16)
+                            PositionEncodingKind::UTF16
                         }
                     })
             });

--- a/crates/llm-ls/src/main.rs
+++ b/crates/llm-ls/src/main.rs
@@ -533,22 +533,27 @@ impl LlmService {
 impl LanguageServer for LlmService {
     async fn initialize(&self, params: InitializeParams) -> LspResult<InitializeResult> {
         *self.workspace_folders.write().await = params.workspace_folders;
-        let position_encoding = params.capabilities.general.and_then(|general_capabilities| {
-            general_capabilities.position_encodings.and_then(|encodings| {
-                if encodings.contains(&PositionEncodingKind::UTF8) {
-                    Some(PositionEncodingKind::UTF8)
-                } else if encodings.contains(&PositionEncodingKind::UTF16) {
-                    Some(PositionEncodingKind::UTF16)
-                } else if encodings.contains(&PositionEncodingKind::UTF32) {
-                    Some(PositionEncodingKind::UTF32)
-                } else {
-                    // Because UTF-16 is the only mandatory encoding that the client must support,
-                    // we will use it as the default encoding.
-                    // See: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocuments
-                    Some(PositionEncodingKind::UTF16)
-                }
-            })
-        });
+        let position_encoding = params
+            .capabilities
+            .general
+            .and_then(|general_capabilities| {
+                general_capabilities
+                    .position_encodings
+                    .and_then(|encodings| {
+                        if encodings.contains(&PositionEncodingKind::UTF8) {
+                            Some(PositionEncodingKind::UTF8)
+                        } else if encodings.contains(&PositionEncodingKind::UTF16) {
+                            Some(PositionEncodingKind::UTF16)
+                        } else if encodings.contains(&PositionEncodingKind::UTF32) {
+                            Some(PositionEncodingKind::UTF32)
+                        } else {
+                            // Because UTF-16 is the only mandatory encoding that the client must support,
+                            // we will use it as the default encoding.
+                            // See: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocuments
+                            Some(PositionEncodingKind::UTF16)
+                        }
+                    })
+            });
 
         *self.position_encoding.write().await = position_encoding.as_ref().unwrap().clone();
 
@@ -620,12 +625,11 @@ impl LanguageServer for LlmService {
         let doc = document_map.get_mut(&uri);
         if let Some(doc) = doc {
             for change in &params.content_changes {
-
                 let position_encoding = match self.position_encoding.read().await.as_str() {
-                        "utf-8" => Some(document::PositionEncodingKind::UTF8),
-                        "utf-16" => Some(document::PositionEncodingKind::UTF16),
-                        "utf-32" => Some(document::PositionEncodingKind::UTF32),
-                        _ => Some(document::PositionEncodingKind::UTF16),
+                    "utf-8" => Some(document::PositionEncodingKind::UTF8),
+                    "utf-16" => Some(document::PositionEncodingKind::UTF16),
+                    "utf-32" => Some(document::PositionEncodingKind::UTF32),
+                    _ => Some(document::PositionEncodingKind::UTF16),
                 };
                 match doc.apply_content_change(change, position_encoding.unwrap()) {
                     Ok(()) => info!("{uri} changed"),


### PR DESCRIPTION
Actually, the only supported encoding was UTF-8.
In cases where the editor sends updates encoded in UTF-16, the mirror of the user's workspace goes out of sync, leading to a server crash.

Furthermore, UTF-16 is the default and mandatory encoding for the protocol, and servers must support it.

Therefore, it is imperative to ensure its support.

Now, to avoid any unnecessary conversion, the server negotiates the encoding with the client during the initialization phase.
This allows the server to choose its preferred encoding in cases where it is available.

See: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocuments